### PR TITLE
pass aldex.glm.effect args to aldex.effect

### DIFF
--- a/R/glm_effect.r
+++ b/R/glm_effect.r
@@ -21,7 +21,7 @@ aldex.glm.effect <- function(clr, verbose=TRUE, include.sample.summary=FALSE, us
         next
       }
 
-      effect.out[[name]] <- aldex.effect(clr, glm.conds=conds)
+      effect.out[[name]] <- aldex.effect(clr, glm.conds=conds, verbose=verbose, include.sample.summary=include.sample.summary, useMC=useMC, CI=CI)
     }
     return(effect.out)
   } else {


### PR DESCRIPTION
Hi, thank you for this really nice package.

I noticed that the parameters for `aldex.glm.effect` are not being passed to `aldex.effect`.  Is there a downside to passing those args?  If not, I have done it here in this pull request.  

One question: This function iterates over the columns of `clr@conds`.  If `include.sample.summary` is `TRUE`, will the median clr values for each sample returned by `aldex.effect` be the same for each iteration?  