### PR TITLE
Updated parameter "test" in aldex.plot and aldex.glm plot to have range of accepted values

### DIFF
--- a/R/plot.aldex.glm.r
+++ b/R/plot.aldex.glm.r
@@ -44,7 +44,7 @@
 #'
 #' @examples # See the examples for 'aldex.glm'
 #' @export
-aldex.glm.plot<-function (x, ..., eff = NULL, contrast=NULL, test = 'fdr', 
+aldex.glm.plot<-function (x, ..., eff = NULL, contrast=NULL, test = c('fdr', 'pval', 'effect'), 
 	type = c("MW", "MA", "volcano"), xlab = NULL, ylab = NULL,
     xlim = NULL, ylim = NULL, all.col = rgb(0, 0, 0, 0.2), all.pch = 19,
     all.cex = 0.4, called.col = "red", called.pch = 20, called.cex = 0.6,
@@ -52,6 +52,7 @@ aldex.glm.plot<-function (x, ..., eff = NULL, contrast=NULL, test = 'fdr',
     cutoff.effect = 1, rare.col = "black", rare = 0, rare.pch = 20,rare.cex = 0.2)
 {
     type <- match.arg(type)
+    test <- match.arg(test)
     if (length(eff) == 0){
         stop("Please run aldex.glm.effect before plotting")
     }

--- a/R/plot.aldex.glm.r
+++ b/R/plot.aldex.glm.r
@@ -13,7 +13,7 @@
 #' http://dx.doi.org/10.1080/10618600.2015.1131161; \code{volcano} is a volcano plot
 #' http://dx.doi.org/10.1186/gb-2003-4-4-210
 #' @param contrast the column name of the model matrix contrast to plot
-#' @param test the method of calculating significance, one of "pval" or "fdr"
+#' @param test the method of calculating significance, one of "pval" or "fdr" or "effect".
 #' @param cutoff.pval the fdr cutoff, default 0.05
 #' @param cutoff.effect the effect size cutoff for plotting, default 1
 #' @param xlab the x-label for the plot, as per the parent \code{plot} function

--- a/R/plot.aldex.r
+++ b/R/plot.aldex.r
@@ -47,7 +47,7 @@
 aldex.plot<-function (x, ..., type = c("MW", "MA", "volcano", "volcano.var"), xlab = NULL, ylab = NULL,
     xlim = NULL, ylim = NULL, all.col = rgb(0, 0, 0, 0.2), all.pch = 19,
     all.cex = 0.4, called.col = "red", called.pch = 20, called.cex = 0.6,
-    thres.line.col = "darkgrey", thres.lwd = 1.5, test = c("welch", "wilcox", "effect", "both")
+    thres.line.col = "darkgrey", thres.lwd = 1.5, test = c("welch", "wilcox", "effect", "both"),
     cutoff.pval = 0.05, cutoff.effect = 1, rare.col = "black", rare = 0, rare.pch = 20,
     rare.cex = 0.2, main=NULL)
 {

--- a/R/plot.aldex.r
+++ b/R/plot.aldex.r
@@ -47,11 +47,12 @@
 aldex.plot<-function (x, ..., type = c("MW", "MA", "volcano", "volcano.var"), xlab = NULL, ylab = NULL,
     xlim = NULL, ylim = NULL, all.col = rgb(0, 0, 0, 0.2), all.pch = 19,
     all.cex = 0.4, called.col = "red", called.pch = 20, called.cex = 0.6,
-    thres.line.col = "darkgrey", thres.lwd = 1.5, test = "welch",
+    thres.line.col = "darkgrey", thres.lwd = 1.5, test = c("welch", "wilcox", "effect", "both")
     cutoff.pval = 0.05, cutoff.effect = 1, rare.col = "black", rare = 0, rare.pch = 20,
     rare.cex = 0.2, main=NULL)
 {
     type <- match.arg(type)
+    test <- match.arg(test)
     if (length(x$effect) == 0)
         stop("Please run aldex.effect before plotting")
     if (test == "welch") {

--- a/R/plot.aldex.r
+++ b/R/plot.aldex.r
@@ -13,7 +13,8 @@
 #' @param test the method of calculating significance, one of:
 #' \code{welch} = welch's t test - here a posterior predictive p-value;
 #' \code{wilcox} = wilcox rank test;
-#' \code{effect} = effect size
+#' \code{effect} = effect size;
+#' \code{both} = welch's t test p value and effect size cutoff. 
 #' @param cutoff.pval the Benjamini-Hochberg fdr cutoff, default 0.05
 #' @param cutoff.effect the effect size cutoff for plotting, default 1
 #' @param xlab the x-label for the plot, as per the parent \code{plot} function


### PR DESCRIPTION
While using aldex.plot, I supplied an invalid value for "test", and instead of throwing an immediate error, it threw an error downstream of that. The if-else structure for different test values initializes different objects for drawing the plot, and an invalid "test" parameter fully avoids that if-else control structure and starts drawing the plot without the necessary objects, creating an error. The cause of the error is also not immediately obvious.

To fix this I used match.arg to restrict "test" in aldex.plot to a range of values corresponding to all possible options in the if-else structure. I applied the same change in aldex.glm.plot and updated the documentation.